### PR TITLE
Fix source views mimetype

### DIFF
--- a/docs/book/bundles/extensions.md
+++ b/docs/book/bundles/extensions.md
@@ -15,7 +15,7 @@ root element of the configuration tree of the extension. And it will make
 life easier to find a certain bundle configuration because elcodi
 follows a common system-wide nomenclature for extension names as well.
 
-```php
+``` php
 // Bundle Extension Class
 
 /**
@@ -44,7 +44,7 @@ implemented mapping configuration node for configuring the respective entity
 mapping override. This configuration tree is always the same so there is
 no need to specify it each time on your custom extension.
 
-```
+``` php
 // Bundle Extension Class
 
 /**
@@ -88,7 +88,7 @@ one. The only thing told to the extension class is the configuration files
 location and which ones to load. If ```getConfigFiles``` returns an empty
 list then nothing will be loaded.
 
-```php
+``` php
 // Bundle Extension Class
 
 /**
@@ -140,7 +140,7 @@ The ```AbstractExtension``` takes this array and prepends this
 configuration into the container ```doctrine``` and ```elcodi_core```
 sections thereby achieving the wanted dynamic mapping behavior.
 
-```php
+``` php
 // Bundle Extension Class
 
 /**
@@ -199,7 +199,7 @@ for the core bundles anymore since this is already done. So they become
 places where we just hook configuration files that usually just have service
 definitions for our glue services.
 
-```php
+``` php
 namespace Elcodi\Admin\AttributeBundle\DependencyInjection;
 
 use Elcodi\Bundle\CoreBundle\DependencyInjection\Abstracts\AbstractExtension;

--- a/docs/book/bundles/extensions.md
+++ b/docs/book/bundles/extensions.md
@@ -6,7 +6,7 @@ reduce boilerplate, enforce the opinions of the framework, improve or ensure
 functioning of the underlying Symfony framework and overall make life easier
 working with the common needs of elcodi bundles.
 
-```AbstractExtension``` is the base class that needs to be extended when
+`AbstractExtension` is the base class that needs to be extended when
 building your own bundle extension classes. This class takes care of the way
 in which configuration is handled in elcodi framework.
 Firstly the class require an extension name which is a snake case version of
@@ -37,8 +37,8 @@ public function getAlias()
 }
 ```
 
-The ```AbstractConfiguration``` class is the base class for all bundle
-configurations. Together with the ```AbstractExtension``` form the
+The `AbstractConfiguration` class is the base class for all bundle
+configurations. Together with the `AbstractExtension` form the
 foundation to enforce elcodi practices in bundles. It also has built-in the
 implemented mapping configuration node for configuring the respective entity
 mapping override. This configuration tree is always the same so there is
@@ -85,7 +85,7 @@ Let's for example load configuration files!
 One has to only list the names of the configuration files that the bundle
 should load and they will be automatically loaded via a file locator one by
 one. The only thing told to the extension class is the configuration files
-location and which ones to load. If ```getConfigFiles``` returns an empty
+location and which ones to load. If `getConfigFiles` returns an empty
 list then nothing will be loaded.
 
 ``` php
@@ -125,19 +125,19 @@ Overriding the mapping on the doctrine section of the container cannot
 be done simply via a compiler pass or on the extension, especially
 when we also want to use parametrized class names. Elcodi base classes
 have already solved this for us using the prepend Symfony container
-feature via implementing the ```PrependExtensionInterface``` interface.
+feature via implementing the `PrependExtensionInterface` interface.
 This method allows us to override sections of other bundles and yet
 keep the flexibility of using parameters that are resolved in the
 container and that can be customized.
 
 If we are to override mapping then our bundle extension should
-implement the interface ```EntitiesOverridableExtensionInterface```
-in addition to extending the ```AbstractExtension``` class. 
-The method ```getEntitiesOverrides``` from the interface should return
+implement the interface `EntitiesOverridableExtensionInterface`
+in addition to extending the `AbstractExtension` class.
+The method `getEntitiesOverrides` from the interface should return
 a key value array where the key is the original interface and the value
 is the fully qualified class name or parameter.
-The ```AbstractExtension``` takes this array and prepends this
-configuration into the container ```doctrine``` and ```elcodi_core```
+The `AbstractExtension` takes this array and prepends this
+configuration into the container `doctrine` and `elcodi_core`
 sections thereby achieving the wanted dynamic mapping behavior.
 
 ``` php

--- a/docs/book/standards/classes.md
+++ b/docs/book/standards/classes.md
@@ -58,7 +58,7 @@ namespaces inside the Trait classes.
 The way of solving this is never using use statements in a Trait, and always 
 using all the namespace when referencing a PHP namespace.
 
-```
+``` php
 trait PriceTrait
 {
     /**

--- a/docs/book/standards/dependency-injection.md
+++ b/docs/book/standards/dependency-injection.md
@@ -10,7 +10,7 @@ start with `elcodi.`.
 
 For example
 
-``` yml
+``` yaml
 elcodi.event_dispatcher.cart
 elcodi.manager.cart
 ```
@@ -22,7 +22,7 @@ We have structured all definitions in three or four levels.
 Most of services will have three levels of definition. Let's analyze previous
 examples:
 
-``` yml
+``` yaml
 elcodi.event_dispatcher.cart
 ```
 
@@ -33,7 +33,7 @@ definition spectre.
 in this example our service will be an EventDispatcher.
 We have some examples of different kind of services in our project
 
-``` yml
+``` yaml
 elcodi.event_dispatcher.cart
 elcodi.event_listener.address_clone_update_carts
 elcodi.manager.cart
@@ -63,7 +63,7 @@ service is not a permanent class but an adapter of an existing port.
 **Third level** is the name of the port. In this example our port is
 `currency_exchange_rate`, a way of calculating rates between currencies.
 
-``` yml
+``` yaml
 elcodi.adapter.currency_exchange_rate.open_exchange
 ```
 

--- a/docs/components/sitemap.md
+++ b/docs/components/sitemap.md
@@ -12,7 +12,7 @@ of sitemap implementation (each element), to the final profiling.
 When we talk about a block, we are really talking about a specific set of 
 entities provided by a specific repository, for example all enabled products.
 
-``` yml
+``` yaml
 # Each block defines a way of creating dynamically a set of elements of a
 # sitemap file, each one mapped from a database entry
 blocks:
@@ -67,7 +67,7 @@ interface SitemapTransformerInterface
 
 Then we need to notice the SitemapBundle the name of the service.
 
-``` yml
+``` yaml
 # Each block defines a way of creating dynamically a set of elements of a
 # sitemap file, each one mapped from a database entry
 blocks:
@@ -83,7 +83,7 @@ retrieved from our database. For this reason you must define as well the
 repository service, the method used and the arguments for such method.
 
 
-``` yml
+``` yaml
 # Each block defines a way of creating dynamically a set of elements of a
 # sitemap file, each one mapped from a database entry
 blocks:
@@ -103,7 +103,7 @@ that every block definition is carefully defined and configured.
 Finally we can define the `changeFrequence` and the `priority` elements. Both 
 values will be used for all block instances. They are not required.
 
-``` yml
+``` yaml
 # Each block defines a way of creating dynamically a set of elements of a
 # sitemap file, each one mapped from a database entry
 blocks:
@@ -265,7 +265,7 @@ Elcodi generates a Dependency Injection service for each builder using our
 standard. In our example, with given configuration we will have available a new
 public service.
 
-``` yml
+``` yaml
 elcodi.sitemap_builder.main
 ```
 
@@ -293,7 +293,7 @@ class SitemapBuilder
 Elcodi generates as well a service for each dumper, using the same notation than
 builders.
 
-``` yml
+``` yaml
 elcodi.sitemap_dumper.main
 ```
 
@@ -369,7 +369,7 @@ languages in our site. This service must return an array of locales.
 
 In elcodi we have a service called `elcodi.languages_iso`.
 
-``` yml
+``` yaml
 elcodi.languages_iso_array:
     class: stdClass
     factory: [@elcodi.languages_iso, toArray]
@@ -381,7 +381,7 @@ elcodi.languages_iso_array:
 Elcodi generates a service for each profile, using our standard. In our example, 
 with given configuration we will have available a new public service.
 
-``` yml
+``` yaml
 elcodi.sitemap_profile.main
 ```
 

--- a/docs/cookbook/caveats/test-suite.md
+++ b/docs/cookbook/caveats/test-suite.md
@@ -41,7 +41,7 @@ rm -rf /tmp/*.backup.database
 
 Running the test suite for elcodi/bamboo is also simple:
 
-```
+``` bash
 php bin/behat
 php bin/phpunit
 ```

--- a/docs/cookbook/implementation/controller-command.md
+++ b/docs/cookbook/implementation/controller-command.md
@@ -20,7 +20,7 @@ service.
 We have a definition about how a Controller and a Command must be registered in
 your DI container
 
-``` yml
+``` yaml
 elcodi.controller.image_upload
 elcodi.command.populate_currency_rates
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -63,7 +63,7 @@ if you have not yet installed Composer, download it following the instructions
 on [http://getcomposer.org/](http://getcomposer.org/) or just run the following
 command:
 
-```bash
+``` bash
     $ curl -s http://getcomposer.org/installer | php
 ```
 
@@ -76,7 +76,7 @@ use any version, but we're still creating new features, fixing some issues and
 errors, and building our first release, so be sure you are not using master, but
 a closed version of the package.
 
-```bash
+``` bash
     $ php composer.phar create-project elcodi/bamboo path/to/your/store/ 0.5.*
 ```
 
@@ -85,7 +85,7 @@ a closed version of the package.
 
 Enter your directory to start the configuration step
 
-```bash
+``` bash
     $ cd path/
 ```
 
@@ -94,7 +94,7 @@ Enter your directory to start the configuration step
 Now we should create the database and all the application schema. Symfony
 provides you an easy way for doing that.
 
-```bash
+``` bash
     $ php app/console doctrine:database:create
     $ php app/console doctrine:schema:create
 ```
@@ -103,7 +103,7 @@ We also load some fixtures to show on our store. This fixtures will set your
 store in a testing mode, with some categories, some manufacturers and a bunch of
 t-shirts. Only for testing purposes :)
 
-```bash
+``` bash
     $ php app/console doctrine:fixtures:load --fixtures="src/Elcodi/Fixtures" --no-interaction
 ```
 
@@ -112,7 +112,7 @@ You can also add the geo information for any country. Just find the two letters
 country you want to load and launch the following command changing ES with your
 code.
 
-```bash
+``` bash
     $ php app/console elcodi:locations:populate ES
 ```
 
@@ -122,7 +122,7 @@ code.
 
 Hey, we have some templates for you! Be sure to load 'em all!
 
-```bash
+``` bash
     $ php app/console elcodi:templates:load
     $ php app/console elcodi:templates:enable StoreTemplateBundle
 ```
@@ -136,7 +136,7 @@ folder.
 
 To install load these plugins, use this command
 
-```bash
+``` bash
     $ php app/console elcodi:plugins:load
 ```
 
@@ -146,7 +146,7 @@ When a store is created it's created "under construction", we can disable that
 mode from the command line. Otherwise, you will not be able to view your new
 awesome store.
 
-```bash
+``` bash
     $ php app/console elcodi:configuration:set store.under_construction "0"
     $ php app/console elcodi:configuration:set store.name "\"My bamboo store\""
 ```
@@ -157,7 +157,7 @@ awesome store.
 
 Finally our store is ready to run :)
 
-```bash
+``` bash
    php app/console server:run
 ```
 
@@ -172,14 +172,14 @@ store interface for your customers and some nice features for administrating it.
 You can start using these credentials we've already created for you. For the
 admin panel use
 
-```
+``` text
 Admin username: admin@admin.com
 Admin password: 1234
 ```
 
 And for the store, use this Customer credentials
 
-```
+``` text
 Customer username: customer@customer.com
 Customer password: 1234
 ```
@@ -199,7 +199,7 @@ yourself that all the cases we've been working on are actually green. We are
 using Behat and PHPUnit, so you only need to execute all suites by using this
 piece of code.
 
-```bash
+``` bash
 php bin/behat
 php bin/phpunit -c app
 ```

--- a/docs/reference/attribute.md
+++ b/docs/reference/attribute.md
@@ -1,7 +1,7 @@
 AttributeBundle Reference
 =========================
 
-```yaml
+``` yaml
 elcodi_attribute:
     
     mapping:

--- a/docs/reference/banner.md
+++ b/docs/reference/banner.md
@@ -1,7 +1,7 @@
 BannerBundle Reference
 ======================
 
-```yaml
+``` yaml
 elcodi_banner:
     
     mapping:

--- a/docs/reference/cart-coupon.md
+++ b/docs/reference/cart-coupon.md
@@ -1,7 +1,7 @@
 CartCouponBundle Reference
 ==========================
 
-```yaml
+``` yaml
 elcodi_cart_coupon:
     
     mapping:

--- a/docs/reference/coupon.md
+++ b/docs/reference/coupon.md
@@ -1,7 +1,7 @@
 CouponBundle Reference
 ======================
 
-```yaml
+``` yaml
 elcodi_coupon:
     
     mapping:


### PR DESCRIPTION
Fix for inline sources and source boxes:
- Inline sources mark is a single ` not 3.
- Boxed sources needs a space after ``` and before the mimetype.
- Boxes sources mimetype is mandatory.
- Yaml mimetype is `yaml`, not `yml`.
