### PR TITLE
Fixed missing internal links

### DIFF
--- a/manuscript/book/plugins.md
+++ b/manuscript/book/plugins.md
@@ -173,7 +173,7 @@ so you will make sure that everybody will understand more easily what you're
 trying to do.
 
 * [How to install dependent Bundles](http://elcodi.io/docs/cookbook/installation/install-dependent-bundles/)
-* [Extensions](http://elcodi.io/docs/book/bundles/extensions/)
+* [Extensions](http://elcodi.io/docs/book/standards/#bundles)
 * [Some Dependency Injection standards](http://elcodi.io/docs/book/standards/dependency-injection/)
 
 Remember to follow some of our philosophy. Small services and well defined.

--- a/manuscript/component/menu.md
+++ b/manuscript/component/menu.md
@@ -487,7 +487,7 @@ This bundle define all changers in this order
 ## Cache
 
 Each changer can be used before or after cache by setting its stage. Please, 
-read the [component documentation](http://elcodi.io/docs/components/menu/) to 
+read the [component documentation](http://elcodi.io/docs/component/menu/) to 
 understand what means this configuration and what is indended for.
 
 ``` yaml

--- a/manuscript/component/metrics.md
+++ b/manuscript/component/metrics.md
@@ -80,7 +80,7 @@ twig, but how many users use the controller.
 
 If our desire is tracking the page view, then you should use the Javascript
 library, designed and created for that purpose. Read the
-[#initializing-metrics](Initializing metrics) section
+Initializing metrics section
 
 ``` jinja
 _etc.push(["123456789", 'homepage', {{user.id}}, '1']);

--- a/manuscript/cookbook/installation/install-a-plugin.md
+++ b/manuscript/cookbook/installation/install-a-plugin.md
@@ -2,7 +2,7 @@ How to Install a plugin
 =======================
 
 To read about plugins, please read all the 
-[Plugins Chapter](http://elcodi.io/docs/book/bundles/plugins/) of our book.
+[Plugins Chapter](http://elcodi.io/docs/book/plugins/) of our book.
 
 To install a plugin, you must treat it as a simple third party bundle.
 


### PR DESCRIPTION
Some internal links were broken, this PR is to fix them or remove the reference.

Broken links:
- http://elcodi.io/docs/book/standards/dependency-injection/
- http://elcodi.io/docs/components/menu/
- http://elcodi.io/docs/component/Initializing%20metrics
- http://elcodi.io/docs/book/bundles/extensions/
- http://elcodi.io/docs/book/bundles/plugins/
